### PR TITLE
Squash new note bug & ensure blank values

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,8 @@ class App extends Component {
 
   toggleNote = () => {
     this.setState({
-      showNote: ! this.state.showNote
+      showNote: ! this.state.showNote,
+      note: {}
     });    
   }
 


### PR DESCRIPTION
The bug appears after viewing the detail page for a given note, and then clicking the Cancel button in the top nav. When the user clicks on the + New Note button in the top-nav, instead of showing a clean slate with blank values in the form, it displays the old data of the previous note that was viewed.
* Adjust src/App.js